### PR TITLE
Fix tests after ChromaDB integration and update README

### DIFF
--- a/documents/tests.py
+++ b/documents/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APIClient
+from unittest.mock import patch, MagicMock
 from rest_framework import status
 from .models import Document
 from .views import DocumentViewSet
@@ -53,70 +54,73 @@ class DocumentViewSetTests(TestCase):
         self.assertIn("Section 2", paragraphs[1])
         self.assertIn("Section 3", paragraphs[2])
 
-    def test_find_relevant_paragraphs(self):
-        """Test the find_relevant_paragraphs method"""
-        # Test with a query about attacking
-        query = "How many dice are rolled when attacking?"
-        paragraphs = self.view.split_into_paragraphs(self.test_content)
-        relevant = self.view.find_relevant_paragraphs(paragraphs, query)
-        
-        # Should find the paragraph about attacking
-        self.assertTrue(any("roll 2 dice" in p for p in relevant))
-        
-        # Test with a query about combat
-        query = "How does combat work?"
-        relevant = self.view.find_relevant_paragraphs(paragraphs, query)
-        
-        # Should find the paragraph about combat
-        self.assertTrue(any("Combat is resolved" in p for p in relevant))
+    # Obsolete tests removed:
+    # test_find_relevant_paragraphs
+    # test_find_relevant_paragraphs_with_keywords
+    # test_find_relevant_paragraphs_with_context
 
-    def test_find_relevant_paragraphs_with_keywords(self):
-        """Test keyword matching in find_relevant_paragraphs"""
-        paragraphs = self.view.split_into_paragraphs(self.test_content)
-        
-        # Test with specific keywords
-        query = "dice attack modifier"
-        relevant = self.view.find_relevant_paragraphs(paragraphs, query)
-        
-        # Should find the paragraph with both dice and attack
-        self.assertTrue(any("roll 2 dice" in p and "attack modifier" in p for p in relevant))
+    @patch('documents.views.get_embeddings_for_texts')
+    @patch('documents.views.get_or_create_collection')
+    def test_document_upload(self, mock_get_collection_upload, mock_get_embeddings_upload):
+        """Test document upload endpoint with ChromaDB/Gemini calls mocked."""
+        # Configure mocks
+        mock_upload_collection = MagicMock()
+        mock_get_collection_upload.return_value = mock_upload_collection
+        # Simulate embedding generation returning a list of embeddings (e.g., one per paragraph)
+        mock_get_embeddings_upload.return_value = [[0.1, 0.2, 0.3]] 
 
-    def test_find_relevant_paragraphs_with_context(self):
-        """Test that relevant paragraphs include proper context"""
-        paragraphs = self.view.split_into_paragraphs(self.test_content)
-        query = "What happens when an attack hits?"
-        relevant = self.view.find_relevant_paragraphs(paragraphs, query)
-        
-        # Should include both the dice rolling and hit condition
-        relevant_text = ' '.join(relevant)
-        self.assertTrue("roll 2 dice" in relevant_text or "attack hits" in relevant_text)
-
-    def test_document_upload(self):
-        """Test document upload endpoint"""
         url = '/api/documents/'
         
         # Create a new test file for upload
-        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as tmp_file:
+        # Using a temporary file for the upload process
+        with tempfile.NamedTemporaryFile(mode='w+b', suffix='.txt', delete=False) as tmp_file:
             tmp_file.write(self.test_content.encode())
-            tmp_file.flush()
+            tmp_file.seek(0) # Rewind to the beginning of the file before reading
             
-            with open(tmp_file.name, 'rb') as file:
-                data = {
-                    'title': 'Test Upload',
-                    'file': file
-                }
+            data = {
+                'title': 'Test Upload',
+                'file': tmp_file # Pass the file object directly
+            }
+            
+            response = self.client.post(url, data, format='multipart')
+        
+        # Clean up the temporary file
+        os.unlink(tmp_file.name)
                 
-                response = self.client.post(url, data, format='multipart')
-                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-                
-                # Verify the document was created
-                self.assertTrue(Document.objects.filter(title='Test Upload').exists())
-                
-                # Clean up
-                os.unlink(tmp_file.name)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Verify the document was created
+        uploaded_doc = Document.objects.filter(title='Test Upload').first()
+        self.assertIsNotNone(uploaded_doc)
+        
+        # Verify mocks were called (basic checks)
+        mock_get_embeddings_upload.assert_called() # Check if it was called
+        mock_upload_collection.add.assert_called() # Check if add was called on the collection
 
-    def test_generate_response(self):
-        """Test the generate_response endpoint"""
+    @patch('documents.views.get_embeddings_for_texts') # Mocks the function in views.py that calls Gemini for embeddings
+    @patch('documents.views.get_or_create_collection') # Mocks ChromaDB collection retrieval
+    @patch('documents.views.genai.GenerativeModel')    # Mocks the Gemini LLM
+    def test_generate_response(self, MockGenerativeModel, mock_get_collection, mock_get_embeddings):
+        """Test the generate_response endpoint with ChromaDB and Gemini mocked."""
+        
+        # --- Mock Gemini Embedding Generation ---
+        # Simulate question embedding
+        mock_get_embeddings.return_value = [[0.1, 0.2, 0.3]] # Example question embedding
+
+        # --- Mock ChromaDB ---
+        mock_collection = MagicMock()
+        # Simulate ChromaDB query result, ensure 'documents' is a list of lists as query() returns
+        mock_collection.query.return_value = {
+            'documents': [['When attacking, roll 2 dice. Add your attack modifier to the result.']] 
+        }
+        mock_get_collection.return_value = mock_collection
+
+        # --- Mock Gemini LLM Response ---
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.generate_content.return_value = MagicMock(text="The AI says: Roll 2 dice when attacking.")
+        MockGenerativeModel.return_value = mock_llm_instance
+        
+        # --- Make the API Call ---
         url = '/api/documents/generate_response/'
         data = {
             'document_id': self.document.id,
@@ -124,15 +128,34 @@ class DocumentViewSetTests(TestCase):
         }
         
         response = self.client.post(url, data, format='json')
+        
+        # --- Assertions ---
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        # Verify the response contains relevant information
         self.assertIn('response', response.data)
+        self.assertEqual(response.data['response'], "The AI says: Roll 2 dice when attacking.")
         self.assertIn('relevant_sections', response.data)
+        # Check that the relevant section from mocked ChromaDB is present
+        self.assertTrue(any('roll 2 dice' in section for section in response.data['relevant_sections']))
+
+        # --- Verify mock calls (optional but good practice) ---
+        # Verify get_embeddings_for_texts was called for the question
+        mock_get_embeddings.assert_called_with(texts=[data['question']], task_type='retrieval_query')
         
-        # Verify the relevant sections contain the dice information
-        relevant_sections = response.data['relevant_sections']
-        self.assertTrue(any('roll 2 dice' in section for section in relevant_sections))
+        # Verify ChromaDB query
+        mock_collection.query.assert_called_once_with(
+            query_embeddings=[[0.1, 0.2, 0.3]], # The mocked question embedding
+            n_results=5, # Default n_results in views.py
+            where={'document_id': str(self.document.id)}
+        )
+        
+        # Verify LLM call
+        # This requires checking the prompt, which can be complex.
+        # For simplicity, just check it was called.
+        mock_llm_instance.generate_content.assert_called_once()
+        # More advanced: capture the prompt and assert its content.
+        # prompt_arg = mock_llm_instance.generate_content.call_args[0][0]
+        # self.assertIn("When attacking, roll 2 dice.", prompt_arg)
+        # self.assertIn(data['question'], prompt_arg)
 
     def test_generate_response_invalid_document(self):
         """Test generate_response with invalid document ID"""


### PR DESCRIPTION
This commit addresses test failures in `documents/tests.py` that occurred after integrating ChromaDB and removing the old TF-IDF logic. It also includes the previous README update.

Key changes:

- Removed obsolete tests in `documents/tests.py` that targeted the deleted `find_relevant_paragraphs` method.
- Modified `test_generate_response` to mock external calls to ChromaDB (`collection.query`) and the Gemini API (`get_embeddings_for_texts`, `genai.GenerativeModel().generate_content`). This makes the test independent of external services and API rate limits.
- Modified `test_document_upload` to mock calls to ChromaDB and embedding generation during the `perform_create` process, ensuring the test focuses on the upload mechanism.
- Updated `README.md` (from previous commit) to reflect the ChromaDB integration, new RAG architecture, environment variables, and other relevant project details.

The test suite should now pass and provide more stable verification of the application's functionality with the new vector store implementation.